### PR TITLE
feat: publish product events to RabbitMQ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -243,6 +243,10 @@ ClientBin/
 *.publishsettings
 orleans.codegen.cs
 
+# SQLite database files
+*.db
+*.db-shm
+*.db-wal
 # Including strong name files can present a security risk
 # (https://github.com/github/gitignore/pull/2483#issue-259490424)
 #*.snk

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  rabbitmq:
+    image: rabbitmq:3-management
+    container_name: rabbitmq
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    environment:
+      RABBITMQ_DEFAULT_USER: guest
+      RABBITMQ_DEFAULT_PASS: guest


### PR DESCRIPTION
### Summary

This PR adds event publishing capabilities to the Inventory API microservice.  
Product-related events are now published to RabbitMQ upon creation, update, or deletion.

### Key Changes

- Added RabbitMQ configuration and exchange setup (`product-events` with `product.*` routing keys)
- Published events in the `ProductController` for `POST`, `PUT`, and `DELETE` actions
- Added `CreateProductDto` and `UpdateProductDto`
- Configured CORS to allow Swagger UI testing
- Used SQLite for lightweight development setup

### Testing

- Run the API
- Use Swagger to create, update, and delete products
- Verify events appear in RabbitMQ queue `product-events-queue`
